### PR TITLE
backends/candle: migrate compute_cap to cudarc 0.19 API

### DIFF
--- a/backends/candle/src/compute_cap.rs
+++ b/backends/candle/src/compute_cap.rs
@@ -3,7 +3,6 @@ use candle::cuda_backend::cudarc::driver;
 use candle::cuda_backend::cudarc::driver::sys::CUdevice_attribute::{
     CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
 };
-use candle::cuda_backend::cudarc::driver::CudaDevice;
 
 pub fn get_compile_compute_cap() -> Result<usize, anyhow::Error> {
     env!("CUDA_COMPUTE_CAP")
@@ -13,13 +12,24 @@ pub fn get_compile_compute_cap() -> Result<usize, anyhow::Error> {
 
 pub fn get_runtime_compute_cap() -> Result<usize, anyhow::Error> {
     driver::result::init().context("CUDA is not available")?;
-    let device = CudaDevice::new(0).context("CUDA is not available")?;
-    let major = device
-        .attribute(CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR)
-        .context("Could not retrieve device compute capability major")?;
-    let minor = device
-        .attribute(CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR)
-        .context("Could not retrieve device compute capability minor")?;
+    // cudarc 0.19 removed `CudaDevice::new`; use the raw driver API to fetch
+    // device attributes without constructing a full CudaContext.
+    let cu_device =
+        driver::result::device::get(0).context("Could not get CUDA device 0")?;
+    let major = unsafe {
+        driver::result::device::get_attribute(
+            cu_device,
+            CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
+        )
+    }
+    .context("Could not retrieve device compute capability major")?;
+    let minor = unsafe {
+        driver::result::device::get_attribute(
+            cu_device,
+            CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR,
+        )
+    }
+    .context("Could not retrieve device compute capability minor")?;
     Ok((major * 10 + minor) as usize)
 }
 


### PR DESCRIPTION
`cudarc 0.19` removed the public `CudaDevice::new` / `CudaDevice::attribute` helpers that `backends/candle/src/compute_cap.rs` used to inspect the runtime GPU's compute capability.

Replace them with the lower-level `driver::result::device` API that still exists in 0.19:

- `driver::result::device::get(ordinal)` → `sys::CUdevice`
- `driver::result::device::get_attribute(dev, attr)` → `i32` (unsafe)

This keeps runtime compute-cap detection working without needing to construct a full `CudaContext` just to read two device attributes.

## Validation

Required for the candle-0.10.1 / cudarc-0.19 lock-step upgrade in [spiceai/spiceai#10278](https://github.com/spiceai/spiceai/pull/10278). Verified by building `spiced --features cuda` against CUDA 12.6 with `CUDA_COMPUTE_CAP=90` — `backends/candle` compiles and the `spiced` binary starts cleanly.

## Risk

Narrow surface: only the CUDA compute-cap probe. No behavior change outside `--features cuda`.
