### PR TITLE
Bump spiceai/candle-* fork revs to candle 0.10.1 / cudarc 0.19 ports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,22 +72,22 @@ candle-nn = { version = "*" }
 candle-transformers = { version = "*" }
 candle-flash-attn = { version = "*" }                                                                                                    #, optional = true }
 candle-flash-attn-v1 = { git = "https://github.com/huggingface/candle-flash-attn-v1", rev = "3f1870b0d708579904c76e41745c659c3f9fa038" } #, optional = true }
-candle-cublaslt = { git = "https://github.com/spiceai/candle-cublaslt", rev = "72be72013e9b9ba69a066aa1920b13255d43959b" }               # , optional = true }
+candle-cublaslt = { git = "https://github.com/spiceai/candle-cublaslt", rev = "b74d30e0a212ee1ee517b2ef2efd8d46ae7687de" }               # , optional = true }
 cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "34834440ada40a7c53d46d45b65d5e42c5f5d903" }                            #, optional = true }
-candle-rotary = { git = "https://github.com/spiceai/candle-rotary", rev = "8a437f99881bd4803f61c7c16ed4367f7cab76fc" }                   #, optional = true }
+candle-rotary = { git = "https://github.com/spiceai/candle-rotary", rev = "a4c4efcd5fcb2d7f750073341f663098c2a50c98" }                   #, optional = true }
 candle-index-select-cu = { version = "0.0.1", features = ["cuda-11"], default-features = false }
 
-candle-layer-norm = { git = "https://github.com/spiceai/candle-layer-norm", rev = "88b9ffdd7077fce11d3f6cb77bbe7093269631fe" } #, optional = true }
+candle-layer-norm = { git = "https://github.com/spiceai/candle-layer-norm", rev = "62f936a1c5c79a08008e6967297543b4c154784e" } #, optional = true }
 
 [patch.crates-io]
 # This could be a problem.
 # cudarc = { git = "https://github.com/Narsil/cudarc", rev = "8b4f18b4bcd5e4b1a9daf40abc3a2e27f83f06e9" }
 cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "34834440ada40a7c53d46d45b65d5e42c5f5d903" }
 #
-candle = { git = "https://github.com/spiceai/candle", rev = "fab4da8172a997bc6dfb4100a51a72d1a7a37988", package = "candle-core" }
-candle-nn = { git = "https://github.com/spiceai/candle", rev = "fab4da8172a997bc6dfb4100a51a72d1a7a37988", package = "candle-nn" }
-candle-transformers = { git = "https://github.com/spiceai/candle", rev = "fab4da8172a997bc6dfb4100a51a72d1a7a37988", package = "candle-transformers" }
-candle-flash-attn = { git = "https://github.com/spiceai/candle", rev = "fab4da8172a997bc6dfb4100a51a72d1a7a37988", package = "candle-flash-attn" }
+candle = { git = "https://github.com/spiceai/candle", rev = "c87b9bc5ddfd4fdd4446ac7efae1566583ab1d55", package = "candle-core" }
+candle-nn = { git = "https://github.com/spiceai/candle", rev = "c87b9bc5ddfd4fdd4446ac7efae1566583ab1d55", package = "candle-nn" }
+candle-transformers = { git = "https://github.com/spiceai/candle", rev = "c87b9bc5ddfd4fdd4446ac7efae1566583ab1d55", package = "candle-transformers" }
+candle-flash-attn = { git = "https://github.com/spiceai/candle", rev = "c87b9bc5ddfd4fdd4446ac7efae1566583ab1d55", package = "candle-flash-attn" }
 [profile.release]
 debug = 0
 lto = "fat"


### PR DESCRIPTION
## Follow-up to #20

Each of the `spiceai/candle-*` sibling crates now has a merged port to `candle-core 0.10.1` and `cudarc 0.19` on its `spiceai` branch. This PR bumps the pinned revs in this workspace's `Cargo.toml` so downstream consumers ([spiceai/spiceai#10278](https://github.com/spiceai/spiceai/pull/10278)) can resolve a single `candle-core 0.10.1` instance through TEI without having to carry any local `[patch]` tables.

### Rev bumps

| Crate | Old rev | New rev | Upstream PR |
|---|---|---|---|
| `spiceai/candle-cublaslt` | `72be7201` | `b74d30e0` | spiceai/candle-cublaslt#5 |
| `spiceai/candle-layer-norm` | `88b9ffdd` | `62f936a1` | spiceai/candle-layer-norm#4 |
| `spiceai/candle-rotary` | `8a437f99` | `a4c4efcd` | spiceai/candle-rotary#3 |
| `spiceai/candle` (core, nn, transformers, flash-attn) | `fab4da81` | `c87b9bc5` | spiceai/candle#12 (rolls in the `candle-flash-attn` `run_mha` FFI softcap fix) |

No `.rs` code changes; only `Cargo.toml` rev pins.

### Verification

Built end-to-end in the `spiceai/spiceai` workspace with `--release --features cuda` on CUDA 12.6 / `CUDA_COMPUTE_CAP=90` using these revs (via a superseded local `[patch]` table), producing a working `spiced v2.0.0-unstable-build.33cea225f+models.cuda` binary. This PR lets [spiceai/spiceai#10278](https://github.com/spiceai/spiceai/pull/10278) drop that patch table entirely.