### PR TITLE
Bump candle rev to 7de0d9fd (picks up moe_gemm_wmma rename to avoid symbol collision)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,10 +84,10 @@ candle-layer-norm = { git = "https://github.com/spiceai/candle-layer-norm", rev 
 # cudarc = { git = "https://github.com/Narsil/cudarc", rev = "8b4f18b4bcd5e4b1a9daf40abc3a2e27f83f06e9" }
 cudarc = { git = "https://github.com/EricLBuehler/cudarc", rev = "34834440ada40a7c53d46d45b65d5e42c5f5d903" }
 #
-candle = { git = "https://github.com/spiceai/candle", rev = "c87b9bc5ddfd4fdd4446ac7efae1566583ab1d55", package = "candle-core" }
-candle-nn = { git = "https://github.com/spiceai/candle", rev = "c87b9bc5ddfd4fdd4446ac7efae1566583ab1d55", package = "candle-nn" }
-candle-transformers = { git = "https://github.com/spiceai/candle", rev = "c87b9bc5ddfd4fdd4446ac7efae1566583ab1d55", package = "candle-transformers" }
-candle-flash-attn = { git = "https://github.com/spiceai/candle", rev = "c87b9bc5ddfd4fdd4446ac7efae1566583ab1d55", package = "candle-flash-attn" }
+candle = { git = "https://github.com/spiceai/candle", rev = "7de0d9fdff7dfb6289442abfba821e8d77f57c58", package = "candle-core" }
+candle-nn = { git = "https://github.com/spiceai/candle", rev = "7de0d9fdff7dfb6289442abfba821e8d77f57c58", package = "candle-nn" }
+candle-transformers = { git = "https://github.com/spiceai/candle", rev = "7de0d9fdff7dfb6289442abfba821e8d77f57c58", package = "candle-transformers" }
+candle-flash-attn = { git = "https://github.com/spiceai/candle", rev = "7de0d9fdff7dfb6289442abfba821e8d77f57c58", package = "candle-flash-attn" }
 [profile.release]
 debug = 0
 lto = "fat"


### PR DESCRIPTION
## Summary

Bumps the `candle` rev from `c87b9bc5` to `7de0d9fd` to pick up [spiceai/candle#13](https://github.com/spiceai/candle/pull/13), which renames candle-kernels' `moe_gemm_wmma` → `candle_moe_gemm_wmma`.

## Why

candle-kernels and mistralrs-core each independently export an `extern "C" void moe_gemm_wmma` kernel (both adapted from [guoqingbao/attention.rs](https://github.com/guoqingbao/attention.rs) but with diverged signatures and implementations). When a binary links both — e.g. `spiced --features cuda,models` pulls in both `text-embeddings-backend-candle` and `mistralrs-core` — `ld.lld` rejects the duplicate symbol:

```
ld.lld: error: duplicate symbol: moe_gemm_wmma
  >>> defined in libmoe.a (from candle-kernels)
  >>> defined in libmistralrscuda.a (from mistralrs-core)
```

Picking up the rename on the candle side resolves it; TEI itself needs no source changes.

## Scope

- Only `Cargo.toml`: candle rev bumped in the root `[workspace.dependencies]` block.
- No TEI source changes.

## Verification

Verified `spiced --features cuda,models` links cleanly on CUDA 12.6 / sm_90 (H100) with the matching spiceai/spiceai pin bump.